### PR TITLE
Find dataset when multiple pools exist on boot

### DIFF
--- a/devsrc/zfs-utils/zfs-utils.initcpio.hook
+++ b/devsrc/zfs-utils/zfs-utils.initcpio.hook
@@ -1,10 +1,21 @@
 ZPOOL_FORCE=""
 
 zfs_get_bootfs () {
-    ZFS_DATASET=`/usr/sbin/zpool list -H -o bootfs | sed 'q'`
-    if [ "$?" != "0" ] || [ "$ZFS_DATASET" = "" ] || [ "$ZFS_DATASET" = "no pools available" ] ; then
-        return 1
-    fi
+    for zfs_dataset in $(/usr/sbin/zpool list -H -o bootfs); do
+        case ${zfs_dataset} in
+            "" | "-")
+                # skip this line/dataset
+                ;;
+            "no pools available")
+                return 1
+                ;;
+            *)
+                ZFS_DATASET=${zfs_dataset}
+                return 0
+                ;;
+        esac
+    done
+    return 1
 }
 
 zfs_mount_handler () {


### PR DESCRIPTION
On my system `rpool` is the internal pool that I boot from. I have an external set of drives that make up the `external` pool. The current zfs hook would only check the first line of the zfs list output and then fail to boot.

With this change, if the `zfs` kernel parameter is set to `bootfs` and multiple pools are available, it will check each pool for the bootfs property and set the first it finds.

As far as I am aware, there are only three possible strings that might be returned by `zpool list -H -o bootfs`, an empty string, `-`, and a dataset name. If this is not the case this change has the potential to break existing systems.
