### PR TITLE
zfs-utils-lts: steal systemd service from upstream

### DIFF
--- a/zfs-utils-lts/50-zfs.preset
+++ b/zfs-utils-lts/50-zfs.preset
@@ -1,0 +1,2 @@
+# ZFS is enabled by default
+enable zfs.*

--- a/zfs-utils-lts/PKGBUILD
+++ b/zfs-utils-lts/PKGBUILD
@@ -17,11 +17,24 @@ url="http://zfsonlinux.org/"
 source=("http://archive.zfsonlinux.org/downloads/zfsonlinux/zfs/zfs-0.6.2.tar.gz"
         "zfs-utils.bash-completion-r1"
         "zfs-utils.initcpio.install"
-        "zfs-utils.initcpio.hook")
+        "zfs-utils.initcpio.hook"
+        "zfs-import-cache.service"
+        "zfs-import-scan.service"
+        "zfs-mount.service"
+        "zfs-share.service"
+        "zfs.target"
+        "50-zfs.preset"
+        )
 md5sums=('0b183b0abdd5be287046ad9ce4f899fd'
          '9ddb0c8a94861f929d0fa741fdc49950'
          'd36549e6e04d817051d50c3636f21132'
-         'ffa2220e660198eaf404daa937394973')
+         'ffa2220e660198eaf404daa937394973'
+         'ccabc291d08b72369d50311ed77b63a8'
+         '8b57107ae89c4bc2aea6a7f6ab967e4e'
+         '9a827c675f00753a63459aaef23c4d78'
+         'c6b9d62ad2c5ef6216b4c674a230c5f3'
+         '33aa777e7d6bd3e3008a10e3a7667f69'
+         '25bab2b91793928591d3830cd32f6077')
 license=("CDDL")
 groups=("archzfs-lts")
 provides=("zfs-utils")
@@ -62,4 +75,12 @@ package() {
     install -D -m644 "${srcdir}"/zfs-utils.initcpio.hook "${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "${srcdir}"/zfs-utils.initcpio.install "${pkgdir}"/usr/lib/initcpio/install/zfs
     install -D -m644 "${srcdir}"/zfs-utils.bash-completion-r1 "${pkgdir}"/usr/share/bash-completion/completions/zfs
+
+    # XXX: steal from the upstream master branch, should be removed in the future
+    install -D -m644 "${srcdir}"/zfs-import-cache.service "${pkgdir}"/usr/lib/systemd/system/zfs-import-cache.service
+    install -D -m644 "${srcdir}"/zfs-import-scan.service "${pkgdir}"/usr/lib/systemd/system/zfs-import-scan.service
+    install -D -m644 "${srcdir}"/zfs-mount.service "${pkgdir}"/usr/lib/systemd/system/zfs-mount.service
+    install -D -m644 "${srcdir}"/zfs-share.service "${pkgdir}"/usr/lib/systemd/system/zfs-share.service
+    install -D -m644 "${srcdir}"/zfs.target "${pkgdir}"/usr/lib/systemd/system/zfs.target
+    install -D -m644 "${srcdir}"/50-zfs.preset "${pkgdir}"/usr/lib/systemd/system-preset/50-zfs.preset
 }

--- a/zfs-utils-lts/zfs-import-cache.service
+++ b/zfs-utils-lts/zfs-import-cache.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Import ZFS pools by cache file
+DefaultDependencies=no
+Requires=systemd-udev-settle.service
+After=systemd-udev-settle.service
+ConditionPathExists=/etc/zfs/zpool.cache
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/zpool import -c /etc/zfs/zpool.cache -aN

--- a/zfs-utils-lts/zfs-import-scan.service
+++ b/zfs-utils-lts/zfs-import-scan.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Import ZFS pools by device scanning
+DefaultDependencies=no
+Requires=systemd-udev-settle.service
+After=systemd-udev-settle.service
+ConditionPathExists=!/etc/zfs/zpool.cache
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/zpool import -d /dev/disk/by-id -aN

--- a/zfs-utils-lts/zfs-mount.service
+++ b/zfs-utils-lts/zfs-mount.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mount ZFS filesystems
+DefaultDependencies=no
+Wants=zfs-import-cache.service
+Wants=zfs-import-scan.service
+Requires=systemd-udev-settle.service
+After=systemd-udev-settle.service
+After=zfs-import-cache.service
+After=zfs-import-scan.service
+Before=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/zfs mount -a

--- a/zfs-utils-lts/zfs-share.service
+++ b/zfs-utils-lts/zfs-share.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ZFS file system shares
+After=nfs-server.service
+After=smb.service
+PartOf=nfs-server.service
+PartOf=smb.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/zfs share -a

--- a/zfs-utils-lts/zfs.target
+++ b/zfs-utils-lts/zfs.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=ZFS startup target
+Requires=zfs-mount.service
+Requires=zfs-share.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
zfs.service was removed from commit 16b015e, and
zfsonlinux/zfs@881f45c has not merged into 0.6.2 yet,
so there is no systemd service to start zfs on boot
currently. I steal some service files from the upstream,
and these files would be removed soon, hopefully.

Signed-off-by: Lance Chen cyen0312@gmail.com
