### PR TITLE
Allow ZFS for /usr or /var, when the root filesystem is not ZFS.

### DIFF
--- a/zfs-utils-git/zfs-utils.initcpio.hook
+++ b/zfs-utils-git/zfs-utils.initcpio.hook
@@ -1,3 +1,5 @@
+#!/usr/bin/ash
+
 ZPOOL_FORCE=""
 
 zfs_get_bootfs () {
@@ -67,6 +69,9 @@ run_hook() {
     fi
 
     case $zfs in
+        "")
+            # skip this line/dataset
+            ;;
         auto|bootfs)
             ZFS_DATASET='bootfs'
             mount_handler="zfs_mount_handler"
@@ -86,6 +91,11 @@ run_hook() {
         [ -c "/dev/zfs" ] && break
         sleep 1
     done
+}
+
+
+run_latehook () {
+    /usr/bin/zpool import -N -a $ZPOOL_FORCE
 }
 
 # vim:set ts=4 sw=4 ft=sh et:


### PR DESCRIPTION
I wanted to have my /var be a ZFS mount, but not the root filesystem. The systemd zfs.target ran too late, and failed as /var was not empty at the time it ran.

Using fstab to mount, also resulted in an error, as the pools had not yet been imported.

This patch to the initcpio hook resolves my issue, and allows the pools to be imported for fstab.
