### PR TITLE
disable rc options

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -3,11 +3,11 @@
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
 openzfs_version="2.3.4"
-openzfs_rc_version="2.4.0-rc1"
+#openzfs_rc_version="2.4.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
 zfs_src_hash="9ec397cf360133161a1180035f3e7d6962186ed2b3457953a28d45aa883fa495"
-zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
+#zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"
 zfs_initcpio_hook_hash="569089e5c539097457a044ee8e7ab9b979dec48f69760f993a6648ee0f21c222"


### PR DESCRIPTION
rc builds are disabled anyway - why bother to keep update unused data?
I kept them in for now so others like me can fork and enable them on thier own - or if this project decides at later point to re-enable them
it's just unnecessary updates/PRs