### PR TITLE
fix: temp workaround for #607

### DIFF
--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -18,7 +18,9 @@ RUN useradd aur && \
 USER aur
 RUN mkdir -p /tmp/ccm-install            && \
     cd /tmp/ccm-install                  && \
-    wget https://aur.archlinux.org/cgit/aur.git/snapshot/clean-chroot-manager.tar.gz && \
+    # FIXME: Temporary workaround for https://github.com/archzfs/archzfs/issues/607
+    # wget https://aur.archlinux.org/cgit/aur.git/snapshot/clean-chroot-manager.tar.gz && \
+    wget https://mirrors.uni-plovdiv.net/aur/clean-chroot-manager.tar.gz && \
     tar -xvf clean-chroot-manager.tar.gz && \
     cd clean-chroot-manager              && \
     makepkg -si --noconfirm              && \


### PR DESCRIPTION
Unfortunately, we're hitting from time to time the problem with the recent [DoS attacks on Arch infrastructure](https://archlinux.org/news/recent-services-outages/), and more specifically on AUR, e.g., from the CI logs:
```
 > [ 5/10] RUN mkdir -p /tmp/ccm-install            &&     cd /tmp/ccm-install                  &&     wget https://aur.archlinux.org/cgit/aur.git/snapshot/clean-chroot-manager.tar.gz &&     tar -xvf clean-chroot-manager.tar.gz &&     cd clean-chroot-manager              &&     makepkg -si --noconfirm              &&     cd /tmp                              &&     rm -rfv /tmp/ccm-install:
0.144 --2025-10-08 14:10:47--  https://aur.archlinux.org/cgit/aur.git/snapshot/clean-chroot-manager.tar.gz
connected.
0.560 GnuTLS: Error in the pull function.
0.560 Unable to establish SSL connection.
```

To be honest, I'd get rid of CCM. It's a fine piece of software that makes things easier, but when I was building archzfs by myself, I dropped it from my build script. Less dependencies, less problems. This would require some work though.

Because #607 left us with a broken repo, we need some urgent solution. This PR is a crude workaround by hosting the CCM distribution tarball from AUR on a mirror. It's not a solution I like, but it should do until we decide how to solve the AUR outage problems.