### PR TITLE
Updated ZFS to 2.4.0

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.3.5"
+openzfs_version="2.4.0"
 openzfs_rc_version="2.4.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="326ae0cba8a615afa42c6891640e76acc4bd230f6d6ddec120c11e30b1392067"
+zfs_src_hash="7bdf13de0a71d95554c0e3e47d5e8f50786c30d4f4b63b7c593b1d11af75c9ee"
 zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
Action completed successfully and the package zfs-linux allowed me to boot.

I'm not sure if I should've removed 2.4.0-rc1, but looking at older releases (2.3) it was kept, so...