### PR TITLE
fix: python bindings installed for 3.13, not 3.14

### DIFF
--- a/src/kernels/_utils.sh
+++ b/src/kernels/_utils.sh
@@ -3,7 +3,7 @@ mode_name="utils"
 mode_desc="Select and use the utils packages"
 
 # version
-pkgrel="1"
+pkgrel="2"
 
 # Version for GIT packages
 pkgrel_git="1"


### PR DESCRIPTION
The recent packages are built correctly, but since their version isn't bumped, the users who have the older packages installed remain with the now outdated Python site-packages install location.

Bumping the pkgrel of zfs-utils to force pacman to update the package.

Fixes #620.