### PR TITLE
Trigger release on new arch kernel package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,23 @@
 on:
+  workflow_dispatch:
+    inputs:
+      kernel_version:
+        required: false
+    types: [arch-kernel-update]
+
   push:
     branches: [master]
     paths:
       - '**.sh'
       - '.github/workflows/**'
+      - '!.github/workflows/watcher.yml'
       - 'build-container/**'
       - 'packages/**'
   schedule:
     - cron: "4 2 * * *"
 
 name: Release
+run-name: ${{ inputs.kernel_version || 'Manual/Cron' }} release
 
 concurrency:
   group: release
@@ -35,7 +43,12 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Build builder container
-        run: docker build -t archzfs-builder build-container
+        env:
+          MIRROR_URL: ${{ vars.MIRROR_URL }}
+        run: |
+          docker build \
+          --build-arg MIRROR_URL=${{ env.MIRROR_URL }} \
+          -t archzfs-builder build-container
 
       - name: Run builder container
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,12 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Build builder container
-        run: docker build -t archzfs-builder build-container
+        env:
+          MIRROR_URL: ${{ vars.MIRROR_URL }}
+        run: |
+          docker build \
+          --build-arg MIRROR_URL=${{ env.MIRROR_URL }} \
+          -t archzfs-builder build-container
 
       - name: Run builder container
         run: docker run -e FAILOVER_RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -1,0 +1,86 @@
+name: Watch for Arch Kernel Updates
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/watcher.yml'
+      - 'nvchecker.toml'
+  schedule:
+    - cron: '10 * * * *'  # Runs every hour at 10 past the hour.
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Install nvchecker
+        run: pip install nvchecker
+
+      - name: Download core.db and extra.db from designated mirror
+        env:
+          MIRROR_URL: ${{ vars.MIRROR_URL }}
+        id: get_mirror_db
+        run: |
+          curl -sS -O $MIRROR_URL/archlinux/core/os/x86_64/core.db
+          curl -sS -O $MIRROR_URL/archlinux/extra/os/x86_64/extra.db
+
+      - name: Generate oldver.json from current GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # || echo is a workaround for repos with no assets (releases)
+          (gh release view --repo ${{ github.repository }} --json assets --jq '.assets[].name' || echo '') > assets.txt
+          
+          get_version() {
+            grep "$1" assets.txt | head -n1 | sed -n 's/.*_\([^-]*\)-.*/\1/p' | sed 's/\.\([0-9]*\)$/-\1/'
+          }
+
+          LINUX_VER=$(get_version 'zfs-linux')
+          LTS_VER=$(get_version 'zfs-linux-lts')
+          HARDENED_VER=$(get_version 'zfs-linux-hardened')
+          ZEN_VER=$(get_version 'zfs-linux-zen')
+
+          cat > oldver.json <<EOF
+          {
+            "linux": "${LINUX_VER:-0.0.0-0}",
+            "linux-lts": "${LTS_VER:-0.0.0-0}",
+            "linux-hardened": "${HARDENED_VER:-0.0.0-0}",
+            "linux-zen": "${ZEN_VER:-0.0.0-0}"
+          }
+          EOF
+
+          echo "Generated oldver.json:"
+          cat oldver.json
+
+      - name: Check for updates
+        id: nvcheck
+        run: |
+          nvchecker -c nvchecker.toml
+          # Produces a string like:
+          # linux 6.18.9.arch1-1 -> 6.18.9.arch1-2 linux-lts 6.12.70-1 -> 6.12.71-1
+          # for the packages that an update is available for
+          UPDATES=$(nvcmp -c nvchecker.toml | tr '\n' ' ')
+
+          if [ -n "$UPDATES" ]; then
+            echo "trigger=true" >> $GITHUB_OUTPUT
+            echo "updates=$UPDATES" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger Release Workflow
+        if: steps.nvcheck.outputs.trigger == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml \
+            --repo ${{ github.repository }} \
+            --ref master \
+            -f kernel_version="${{ steps.nvcheck.outputs.updates }}"

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -1,4 +1,7 @@
 name: Watch for Arch Kernel Updates
+permissions:
+  contents: read
+  actions: write
 
 on:
   push:

--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -1,7 +1,16 @@
 FROM archlinux:base-devel
 
+# Set up the mirror from mirror-url
+ARG MIRROR_URL
+ENV MIRROR_URL=$MIRROR_URL
+
+USER root
+RUN echo "Server = ${MIRROR_URL}/archlinux/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist
+
 # The following is adapted from https://github.com/archzfs/archzfs-ci/blob/master/worker/Dockerfile
 RUN pacman -Syu --noconfirm --needed python-pipx python-twisted git wget systemd-sysvcompat openresolv vi
+# Confirm the mirror is set, done after sync
+RUN pacman -Sp linux linux-lts linux-hardened linux-zen linux-headers linux-lts-headers linux-hardened-headers linux-zen-headers
 
 # add buildbot user and give passwordless sudo access (needed for archzfs build scripts)
 RUN groupadd -r buildbot && \

--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -1,6 +1,5 @@
 FROM archlinux:base-devel
 
-# Set up the mirror from mirror-url
 ARG MIRROR_URL
 ENV MIRROR_URL=$MIRROR_URL
 

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -40,6 +40,13 @@ if [ ! -z "${FAILOVER_RELEASE_NAME}" ]; then
     fi
 fi
 
+if [ ! -z "${MIRROR_URL}" ]; then
+    echo "==> Forcing system mirror to: ${MIRROR_URL}"
+    echo "Server = ${MIRROR_URL}/archlinux/\$repo/os/\$arch" | sudo tee /etc/pacman.d/mirrorlist
+else
+    echo "!! WARNING: MIRROR_URL was not set. Using default mirrors."
+fi
+
 sudo chown -R buildbot:buildbot /src
 cd /src
 

--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -1,0 +1,19 @@
+[__config__]
+oldver = "oldver.json"
+newver = "newver.json"
+
+[linux]
+source = "cmd"
+cmd = "tar -tzf core.db | sed -nE 's|^linux-([0-9].*?)/$|\\1|p'"
+
+[linux-lts]
+source = "cmd"
+cmd = "tar -tzf core.db | sed -nE 's|^linux-lts-([0-9].*?)/$|\\1|p'"
+
+[linux-hardened]
+source = "cmd"
+cmd = "tar -tzf extra.db | sed -nE 's|^linux-hardened-([0-9].*?)/$|\\1|p'"
+
+[linux-zen]
+source = "cmd"
+cmd = "tar -tzf extra.db | sed -nE 's|^linux-zen-([0-9].*?)/$|\\1|p'"


### PR DESCRIPTION
#626 but as a local branch so the tests can run

This PR introduces automated triggering of ZFS package releases when new Arch Linux kernel packages are published. This works by comparing the assets (releases) in github for the repo with the latest packages in a given mirror. To avoid a sort of race condition where not all mirrors have the same releases, we force the same mirror throughout the entire build process, I've already configured `vars.MIRROR_URL` to the friendly mirror mentioned in #612, so it should work as soon as it's merged. 

I've also added some comments to the PR to explain things / flag parts i'm not sure about.


https://github.com/loadedice/archzfs/actions/runs/22078285597 is a real example of a build that was kicked off when a new kernel was released.

it was triggered by this run of the watcher https://github.com/loadedice/archzfs/actions/runs/22078280303



Closes https://github.com/archzfs/archzfs/issues/612