### PR TITLE
Only build affected kernel package on watcher trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,21 @@ on:
     inputs:
       kernel_version:
         required: false
-    types: [arch-kernel-update]
+      # Set build_linux, etc to default to true for the cron job.
+      # That can be removed when we are comfortable with watcher, and make default false.
+      build_linux:
+        required: false
+        default: 'true'
+      build_linux_lts:
+        required: false
+        default: 'true'
+      build_linux_hardened:
+        required: false
+        default: 'true'
+      build_linux_zen:
+        required: false
+        default: 'true'
+
 
   push:
     branches: [master]
@@ -54,7 +68,16 @@ jobs:
         env:
           GPG_KEY_DATA: "${{ secrets.GPG_KEY_DATA }}"
           GPG_KEY_ID: "${{ vars.GPG_KEY_ID }}"
-        run: docker run -e GPG_KEY_DATA -e GPG_KEY_ID -e FAILOVER_RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder
+          BUILD_LINUX: "${{ inputs.build_linux }}"
+          BUILD_LINUX_LTS: "${{ inputs.build_linux_lts }}"
+          BUILD_LINUX_HARDENED: "${{ inputs.build_linux_hardened }}"
+          BUILD_LINUX_ZEN: "${{ inputs.build_linux_zen }}"
+        run: |
+          docker run \
+          -e GPG_KEY_DATA -e GPG_KEY_ID \
+          -e FAILOVER_RELEASE_NAME \
+          -e BUILD_LINUX -e BUILD_LINUX_LTS -e BUILD_LINUX_HARDENED -e BUILD_LINUX_ZEN \
+          --privileged --rm -v "$(pwd):/src" archzfs-builder
 
       - name: Delete possible leftover temporary release
         env:

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -76,6 +76,12 @@ jobs:
           if [ -n "$UPDATES" ]; then
             echo "trigger=true" >> $GITHUB_OUTPUT
             echo "updates=$UPDATES" >> $GITHUB_OUTPUT
+
+            # Parse each kernel explicitly
+            echo "$UPDATES" | grep -qE '(^| )linux ' && echo "build_linux=true" >> $GITHUB_OUTPUT
+            echo "$UPDATES" | grep -q 'linux-lts' && echo "build_linux_lts=true" >> $GITHUB_OUTPUT
+            echo "$UPDATES" | grep -q 'linux-hardened' && echo "build_linux_hardened=true" >> $GITHUB_OUTPUT
+            echo "$UPDATES" | grep -q 'linux-zen' && echo "build_linux_zen=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Trigger Release Workflow
@@ -86,4 +92,8 @@ jobs:
           gh workflow run release.yml \
             --repo ${{ github.repository }} \
             --ref master \
-            -f kernel_version="${{ steps.nvcheck.outputs.updates }}"
+            -f kernel_version="${{ steps.nvcheck.outputs.updates }}" \
+            -f build_linux="${{ steps.nvcheck.outputs.build_linux || 'false' }}" \
+            -f build_linux_lts="${{ steps.nvcheck.outputs.build_linux_lts || 'false' }}" \
+            -f build_linux_hardened="${{ steps.nvcheck.outputs.build_linux_hardened || 'false' }}" \
+            -f build_linux_zen="${{ steps.nvcheck.outputs.build_linux_zen || 'false' }}"

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -65,6 +65,7 @@ jobs:
           cat oldver.json
 
       - name: Check for updates
+        continue-on-error: true # Continue if grep doesn't match all.
         id: nvcheck
         run: |
           nvchecker -c nvchecker.toml


### PR DESCRIPTION
Followup to https://github.com/archzfs/archzfs/pull/627 (Not merged yet)

Modifies the release workflow to only build certain kernel packages based off what versions need updating. This utilises the existing "failover" method when doing a re-release, but this does feel like a bit of a hack, ideally we'd just update the files that need it, but imo this is good enough.

This means that the build is faster when only a subset of kernels needs an update and I think we might be able to take this solution to help with https://github.com/archzfs/archzfs/issues/613 if we have a good criteria on when `utils` and `dkms` _need_ to be built (I am not sure _when_ they need updates? Only when OpenZFS is bumped maybe?)

Split this into 2 different PRs because I think it's easier to review this way, smaller diffs.

This has been running in the archzfs-testing repo since https://github.com/archzfs/archzfs-testing/pull/6 and https://github.com/archzfs/archzfs-testing/pull/4 were merged (~ 1 week ago) and seems to be working well so far.

If https://github.com/archzfs/archzfs/pull/627 gets merged I will set the base branch for this to master and undraft the PR.