### PR TITLE
Automate OpenZFS updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
       - '**.sh'
       - '.github/workflows/**'
       - '!.github/workflows/watcher.yml'
+      - '!.github/workflows/update-zfs.yml'
       - 'build-container/**'
       - 'packages/**'
   schedule:

--- a/.github/workflows/update-zfs.yml
+++ b/.github/workflows/update-zfs.yml
@@ -1,0 +1,56 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New OpenZFS version'
+        required: true
+
+name: Update OpenZFS
+run-name: Create PR to update OpenZFS to ${{ inputs.version }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Get release hash from GitHub
+        id: get_hash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          FILENAME="zfs-${VERSION}.tar.gz"
+
+          DIGEST=$(gh api "repos/openzfs/zfs/releases/tags/zfs-${VERSION}" \
+            --jq ".assets[] | select(.name == \"$FILENAME\") | .digest")
+
+          HASH=${DIGEST#sha256:}
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Update conf.sh
+        env:
+          VERSION: ${{ inputs.version }}
+          HASH: ${{ steps.get_hash.outputs.hash }}
+        run: |
+          
+          # Replace version and hash in conf.sh
+          sed -i "s/^openzfs_version=\".*\"/openzfs_version=\"${VERSION}\"/" conf.sh
+          sed -i "s/^zfs_src_hash=\".*\"/zfs_src_hash=\"${HASH}\"/" conf.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8.1.0
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update OpenZFS to ${{ inputs.version }}"
+          title: "Update OpenZFS to ${{ inputs.version }}"
+          body: |
+            Automated PR triggered by nvchecker. Updates `openzfs_version` to **${{ inputs.version }}**.
+          branch: "update-openzfs-${{ inputs.version }}"
+          base: master
+

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -74,13 +74,15 @@ jobs:
         run: |
           nvchecker -c nvchecker.toml
           # Produces a string like:
-          # linux 6.18.9.arch1-1 -> 6.18.9.arch1-2 linux-lts 6.12.70-1 -> 6.12.71-1
+          # linux 6.18.9.arch1-1 -> 6.18.9.arch1-2 linux-lts 6.12.70-1 -> 6.12.71-1 openzfs 2.4.0 -> 2.4.1
           # for the packages that an update is available for
           UPDATES=$(nvcmp -c nvchecker.toml | tr '\n' ' ')
 
           if [ -n "$UPDATES" ]; then
-            # TODO: Remove ZFS updates from this string, rename var to "kerenl updates"
-            echo "updates=$UPDATES" >> $GITHUB_OUTPUT
+            # Remove ZFS updates
+            KERNEL_UPDATES=$(echo "$UPDATES" | sed 's/openzfs [^ ]* -> [^ ]*//g')
+            # Write the new variable to the GitHub Actions output environment
+            echo "kernel_updates=$KERNEL_UPDATES" >> "$GITHUB_OUTPUT"
 
             # Parse each kernel explicitly
             echo "$UPDATES" | grep -qE '(^| )linux ' && echo "build_linux=true" >> $GITHUB_OUTPUT
@@ -107,7 +109,7 @@ jobs:
           gh workflow run release.yml \
             --repo ${{ github.repository }} \
             --ref master \
-            -f kernel_version="${{ steps.nvcheck.outputs.updates }}" \
+            -f kernel_version="${{ steps.nvcheck.outputs.kernel_updates }}" \
             -f build_linux="${{ steps.nvcheck.outputs.build_linux || 'false' }}" \
             -f build_linux_lts="${{ steps.nvcheck.outputs.build_linux_lts || 'false' }}" \
             -f build_linux_hardened="${{ steps.nvcheck.outputs.build_linux_hardened || 'false' }}" \

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -1,4 +1,4 @@
-name: Watch for Arch Kernel Updates
+name: Watch for Upstream Updates
 permissions:
   contents: read
   actions: write
@@ -52,12 +52,16 @@ jobs:
           HARDENED_VER=$(get_version 'zfs-linux-hardened')
           ZEN_VER=$(get_version 'zfs-linux-zen')
 
+          # Extract current OpenZFS version from conf.sh
+          ZFS_VER=$(grep '^openzfs_version=' conf.sh | cut -d'"' -f2)
+
           cat > oldver.json <<EOF
           {
             "linux": "${LINUX_VER:-0.0.0-0}",
             "linux-lts": "${LTS_VER:-0.0.0-0}",
             "linux-hardened": "${HARDENED_VER:-0.0.0-0}",
-            "linux-zen": "${ZEN_VER:-0.0.0-0}"
+            "linux-zen": "${ZEN_VER:-0.0.0-0}",
+            "openzfs": "${ZFS_VER:-0.0.0}"
           }
           EOF
 
@@ -75,7 +79,7 @@ jobs:
           UPDATES=$(nvcmp -c nvchecker.toml | tr '\n' ' ')
 
           if [ -n "$UPDATES" ]; then
-            echo "trigger=true" >> $GITHUB_OUTPUT
+            # TODO: Remove ZFS updates from this string, rename var to "kerenl updates"
             echo "updates=$UPDATES" >> $GITHUB_OUTPUT
 
             # Parse each kernel explicitly
@@ -83,10 +87,20 @@ jobs:
             echo "$UPDATES" | grep -q 'linux-lts' && echo "build_linux_lts=true" >> $GITHUB_OUTPUT
             echo "$UPDATES" | grep -q 'linux-hardened' && echo "build_linux_hardened=true" >> $GITHUB_OUTPUT
             echo "$UPDATES" | grep -q 'linux-zen' && echo "build_linux_zen=true" >> $GITHUB_OUTPUT
+
+            if echo "$UPDATES" | grep -q 'openzfs'; then
+              echo "update_openzfs=true" >> $GITHUB_OUTPUT
+              ZFS_NEW=$(echo "$UPDATES" | sed -n 's/.*openzfs [^ ]* -> \([^ ]*\).*/\1/p')
+              echo "openzfs_version=$ZFS_NEW" >> $GITHUB_OUTPUT
+            fi
           fi
 
-      - name: Trigger Release Workflow
-        if: steps.nvcheck.outputs.trigger == 'true'
+      - name: Trigger Kernel Release Workflow
+        if: >
+          steps.nvcheck.outputs.build_linux == 'true' || 
+          steps.nvcheck.outputs.build_linux_lts == 'true' || 
+          steps.nvcheck.outputs.build_linux_hardened == 'true' || 
+          steps.nvcheck.outputs.build_linux_zen == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -98,3 +112,27 @@ jobs:
             -f build_linux_lts="${{ steps.nvcheck.outputs.build_linux_lts || 'false' }}" \
             -f build_linux_hardened="${{ steps.nvcheck.outputs.build_linux_hardened || 'false' }}" \
             -f build_linux_zen="${{ steps.nvcheck.outputs.build_linux_zen || 'false' }}"
+
+      - name: Trigger OpenZFS Update PR
+        if: steps.nvcheck.outputs.update_openzfs == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_ZFS_VERSION: ${{ steps.nvcheck.outputs.openzfs_version }}
+        run: |
+          # Check if an open PR already exists for this specific branch
+          PR_EXISTS=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --head "update-openzfs-$NEW_ZFS_VERSION" \
+            --json number \
+            --jq 'length')
+
+          if [ "$PR_EXISTS" -gt "0" ]; then
+            echo "An open PR for OpenZFS $NEW_ZFS_VERSION already exists. Skipping workflow trigger."
+          else
+            echo "No existing PR found. Triggering update-zfs.yml for version $NEW_ZFS_VERSION."
+            gh workflow run update-zfs.yml \
+              --repo ${{ github.repository }} \
+              --ref master \
+              -f version="$NEW_ZFS_VERSION"
+          fi

--- a/nvchecker.toml
+++ b/nvchecker.toml
@@ -17,3 +17,9 @@ cmd = "tar -tzf extra.db | sed -nE 's|^linux-hardened-([0-9].*?)/$|\\1|p'"
 [linux-zen]
 source = "cmd"
 cmd = "tar -tzf extra.db | sed -nE 's|^linux-zen-([0-9].*?)/$|\\1|p'"
+
+[openzfs]
+source = "github"
+github = "openzfs/zfs"
+use_max_release = true
+prefix = "zfs-"


### PR DESCRIPTION
Automatically raises a PR to update conf.sh when a new openzfs version is released.

Closes https://github.com/archzfs/archzfs/issues/629

Requires https://github.com/archzfs/archzfs/pull/627 and https://github.com/archzfs/archzfs/pull/632 to be merged first

I've been testing this in my fork for a while, and merged it to the testing branch recently.

In the testing repo I reverted the most recent upgrade to 2.4.1 to 2.4.0, and it raised this PR: https://github.com/archzfs/archzfs-testing/pull/8 which I've merged now.

It was triggered by this invocation of the watcher: https://github.com/archzfs/archzfs-testing/actions/runs/22781923744/job/66089605799

Which triggered the new workflow to raise a PR: https://github.com/archzfs/archzfs-testing/actions/runs/22781931460

---

NOTE:
Repo must set this configuration in the setting to allow a PR to be raised:

<img width="803" height="343" alt="2026-03-07-08:01:58" src="https://github.com/user-attachments/assets/099addba-c7c4-4e74-b356-84567fc744a4" />


I didn't need to (and couldn't) set this in the testing repo, but it worked out of the box so perhaps this is the default? Please double check before merging this 