### PR TITLE
Remove `sudoers.d` Permission Changes from `zfs-utils` PKGBUILD

### DIFF
--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -51,10 +51,6 @@ package() {
     mkdir -p "\${pkgdir}/etc/modules-load.d"
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
 
-    # fix permissions
-    #chmod 750 \${pkgdir}/etc/sudoers.d
-    #chmod 440 \${pkgdir}/etc/sudoers.d/zfs
-
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.install "\${pkgdir}"/usr/lib/initcpio/install/zfs

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -25,7 +25,7 @@ provides=("zfs-utils" "spl-utils")
 install=zfs-utils.install
 conflicts=("zfs-utils" "spl-utils")
 ${zfs_utils_replaces}
-backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf' 'etc/sudoers.d/zfs')
+backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
 
 build() {
     cd "${zfs_workdir}"

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -52,8 +52,8 @@ package() {
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
 
     # fix permissions
-    chmod 750 \${pkgdir}/etc/sudoers.d
-    chmod 440 \${pkgdir}/etc/sudoers.d/zfs
+    #chmod 750 \${pkgdir}/etc/sudoers.d
+    #chmod 440 \${pkgdir}/etc/sudoers.d/zfs
 
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs


### PR DESCRIPTION
As of https://github.com/openzfs/zfs/commit/2076569ce886058db860232d4db84443c05044a1, the `/etc/sudoers.d/zfs` file no longer exists.