### PR TITLE
update to zfs 2.4.3

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.4.2"
+openzfs_version="2.4.3"
 openzfs_rc_version="2.4.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f"
+zfs_src_hash="1f08f2d154f5189b5f1382848a32667b3d34066145b474c49cd3d41a5fba59a7"
 zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -51,10 +51,6 @@ package() {
     mkdir -p "\${pkgdir}/etc/modules-load.d"
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
 
-    # fix permissions
-    #chmod 750 \${pkgdir}/etc/sudoers.d
-    #chmod 440 \${pkgdir}/etc/sudoers.d/zfs
-
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.install "\${pkgdir}"/usr/lib/initcpio/install/zfs

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -25,7 +25,7 @@ provides=("zfs-utils" "spl-utils")
 install=zfs-utils.install
 conflicts=("zfs-utils" "spl-utils")
 ${zfs_utils_replaces}
-backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf' 'etc/sudoers.d/zfs')
+backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
 
 build() {
     cd "${zfs_workdir}"

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -52,8 +52,8 @@ package() {
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
 
     # fix permissions
-    chmod 750 \${pkgdir}/etc/sudoers.d
-    chmod 440 \${pkgdir}/etc/sudoers.d/zfs
+    #chmod 750 \${pkgdir}/etc/sudoers.d
+    #chmod 440 \${pkgdir}/etc/sudoers.d/zfs
 
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs


### PR DESCRIPTION
ZTS result: https://github.com/n0xena/archzfs/pull/38#issuecomment-4699146036
note: 2.4.3 doesn't support linux 7.1 yet - so 2.4.4 with support for linux 7.1 is to be expect rather quick