### PR TITLE
docs: add project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Welcome to the ArchZFS project. This repo contains everything used to deploy ZFS
 
 Take a look at the [wiki](https://github.com/archzfs/archzfs/wiki) for user
 documentation. The [architecture](docs/architecture.md) document describes the
-current build and release system. Contributors and automation agents should
-also read the repository's [agent instructions](AGENTS.md).
+current build and release system, while the [roadmap](docs/roadmap.md) records
+maintainer direction and unresolved policy. Contributors and automation agents
+should also read the repository's [agent instructions](AGENTS.md).
 
 ## Licenses
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # ArchZFS Architecture
 
 This document describes the currently deployed ArchZFS system. Proposed release
-channels and unfinished infrastructure belong in roadmap documentation, not in
-this current-state reference.
+channels and unfinished infrastructure are tracked in the
+[project roadmap](roadmap.md), not in this current-state reference.
 
 ## Repository Responsibilities
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,19 +1,19 @@
 # ArchZFS Roadmap
 
-Last reviewed: 2026-07-11
+Last reviewed: 2026-07-12
 
-This document records maintainer direction and open design work. It is not a
-release schedule, and nothing described as staging, proposed, or requiring
-design is deployed production behavior. See [architecture.md](architecture.md)
-for the current system.
+This document records the current maintainer's working direction and open design
+work. It is not a release schedule, and nothing described as staging, proposed,
+or requiring design is deployed production behavior. See
+[architecture.md](architecture.md) for the current system.
 
 Status terms used below:
 
 - **Deployed**: available through the production ArchZFS system.
 - **Staging**: implemented or exercised outside production, primarily in
   `archzfs-testing`.
-- **Priority**: accepted as important current work, but not necessarily designed
-  or implemented completely.
+- **Priority**: identified by the current maintainer as important current work,
+  but not necessarily agreed project-wide, designed, or implemented completely.
 - **Design needed**: desired outcome with unresolved policy or implementation.
 - **Historical**: retained context, not a supported direction.
 
@@ -211,9 +211,11 @@ path until the package and migration instructions are deployed.
 **Status: Design needed**
 
 Define authoritative sources, signature checks, and retention for official Arch
-kernel packages included in stable. Coordinate that policy with mirror archives
-and the separately maintained historical packages at `kernels.archzfs.com`, but
-do not make a self-contained stable repository depend on that external service.
+kernel packages included in stable. Treat `kernels.archzfs.com` only as a
+historical lead: its HTTPS endpoint is currently unusable because its certificate
+does not match the hostname, and its maintenance and retention status must be
+established before it can be considered in distribution planning. A
+self-contained stable repository must not depend on it.
 
 Resolve the remaining `archzfs.com` domain, redirect, user-migration, and archive
 questions tracked in [issue #599](https://github.com/archzfs/archzfs/issues/599).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,13 +107,16 @@ should be demonstrated there before entering this production repository.
 **Status: Priority; implementation proposed in
 [archzfs-mirror PR #1](https://github.com/archzfs/archzfs-mirror/pull/1)**
 
-The Plovdiv HTTPS/rsync endpoint is online, but the proposed synchronization
-tooling is unfinished and not deployed, so it is not currently refreshed from
-production releases automatically. Refine the Tier 1/Tier 2 implementation,
-preserve its staging, locking, managed-deletion, API-limit, and archive safety
-properties, and verify release and package signatures before downloaded assets
-become visible. Add deployment, recovery, monitoring, and retention
-documentation, then deploy and observe it on the Plovdiv server.
+The public mirror hosted by the
+[Computer-Assisted Research and Teaching Laboratory](https://cart.uni-plovdiv.net/)
+at the [University of Plovdiv](https://uni-plovdiv.bg/) is online, but the
+proposed synchronization tooling is unfinished and not deployed, so it is not
+currently refreshed from production releases automatically. Refine the Tier 1
+and Tier 2 implementation, preserve its staging, locking, managed-deletion,
+API-limit, and archive safety properties, and verify release and package
+signatures before downloaded assets become visible. Add deployment, recovery,
+monitoring, and retention documentation, then deploy and observe it on the
+University-hosted mirror.
 
 This work is a high priority because it improves an existing service without
 first changing production package-selection or release-trigger behavior.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,245 @@
+# ArchZFS Roadmap
+
+Last reviewed: 2026-07-11
+
+This document records maintainer direction and open design work. It is not a
+release schedule, and nothing described as staging, proposed, or requiring
+design is deployed production behavior. See [architecture.md](architecture.md)
+for the current system.
+
+Status terms used below:
+
+- **Deployed**: available through the production ArchZFS system.
+- **Staging**: implemented or exercised outside production, primarily in
+  `archzfs-testing`.
+- **Priority**: accepted as important current work, but not necessarily designed
+  or implemented completely.
+- **Design needed**: desired outcome with unresolved policy or implementation.
+- **Historical**: retained context, not a supported direction.
+
+## Principles
+
+- Keep production build and publication infrastructure reproducible through
+  GitHub rather than dependent on one maintainer's host or private services.
+- Test every package set before it reaches an end-user channel. Prefer ephemeral
+  artifacts that are never published when validation fails.
+- Classify an end-user channel by upstream release status, kernel support, patch
+  provenance, and intended audience. Passing tests is necessary but does not by
+  itself make unreleased upstream code stable.
+- Preserve signed, create-then-promote publication for fixed-name channels so a
+  failed upload does not immediately replace the working repository and GitHub
+  displays a meaningful publication date.
+- Keep channel names provisional until their contents, audience, migration, and
+  support expectations are agreed and documented.
+
+## Release Roles
+
+These roles describe policy. Except where noted, their final GitHub release and
+Pacman repository names remain design decisions.
+
+### Stable
+
+**Status: Design needed**
+
+The stable end-user repository should provide:
+
+- The latest suitable released OpenZFS version, without unreleased feature or
+  kernel-compatibility patches.
+- Only kernel combinations inside that OpenZFS release's declared support
+  range. A successful build against a newer kernel is not sufficient.
+- Matching, unmodified official Arch Linux kernel and header packages so the
+  repository remains usable after official Arch repositories advance.
+- Verification and redistribution of the original Arch package signatures,
+  alongside normal ArchZFS signing for ArchZFS-built packages and repository
+  metadata.
+- A retention policy that keeps a complete compatible package set available
+  long enough for upgrades and fresh installations.
+
+This definition combines compatibility policy with operational maturity. The
+current public `experimental` release uses proven infrastructure but does not
+enforce these compatibility and self-containment requirements; it therefore
+cannot become stable through a name change alone.
+
+### Compatibility Edge
+
+**Status: Design needed; the current `experimental` name may be reused or
+replaced**
+
+This end-user repository would follow current Arch kernels before a compatible
+OpenZFS release is available. It may use narrowly selected compatibility work
+from OpenZFS `master` or upstream pull requests. Its packages must pass the same
+automated validation required for other public channels, but remain higher-risk
+because tests cannot establish the maturity of unreleased upstream changes or
+find every bug exposed by real workloads.
+
+This role is comparable to an upstream testing repository, not to a staging
+area for ArchZFS CI implementation changes.
+
+### Feature Preview
+
+**Status: Design needed; optional**
+
+Substantial unreleased OpenZFS features or broader patch sets may warrant a
+separate, more explicitly experimental end-user channel. Before creating one,
+decide whether there is a real audience, how it differs from compatibility
+edge, and what support and retention users can expect.
+
+### CI Validation
+
+**Status: Partially deployed**
+
+Package candidates should normally exist only as ephemeral workflow artifacts
+until validation succeeds. A mutable release such as `testing` may be used when
+persistent assets are technically necessary, but it is not an end-user channel
+and developers should rarely need to install from it. The current shared release
+also cannot be updated reliably by fork-originated pull requests because of
+GitHub token permissions tracked in
+[issue #586](https://github.com/archzfs/archzfs/issues/586).
+
+`archzfs-testing` has a separate purpose: it is the disposable staging fork for
+release-infrastructure changes. Watchers, publication changes, and other CI work
+should be demonstrated there before entering this production repository.
+
+## Immediate Priorities
+
+### Mirror Automation
+
+**Status: Priority; implementation proposed in
+[archzfs-mirror PR #1](https://github.com/archzfs/archzfs-mirror/pull/1)**
+
+The Plovdiv HTTPS/rsync endpoint is online, but the proposed synchronization
+tooling is unfinished and not deployed, so it is not currently refreshed from
+production releases automatically. Refine the Tier 1/Tier 2 implementation,
+preserve its staging, locking, managed-deletion, API-limit, and archive safety
+properties, and verify release and package signatures before downloaded assets
+become visible. Add deployment, recovery, monitoring, and retention
+documentation, then deploy and observe it on the Plovdiv server.
+
+This work is a high priority because it improves an existing service without
+first changing production package-selection or release-trigger behavior.
+
+### Kernel Watcher Foundation
+
+**Status: Priority and staging in `archzfs-testing`; proposed in
+[PR #627](https://github.com/archzfs/archzfs/pull/627)**
+
+Review and refine the watcher, then merge it as the foundation for later release
+automation. It should continue to track all supported Arch kernel families and
+use the same configurable mirror for detection and builds. Keep version
+detection separate from channel policy: a new kernel may trigger a normal
+stable rebuild, require compatibility-edge patches, or require stable to retain
+an older official kernel.
+
+### Selective Package Updates
+
+**Status: Staging; dependent proposal in
+[PR #632](https://github.com/archzfs/archzfs/pull/632)**
+
+After the watcher foundation, rebuild only affected kernel families and retain
+unchanged signed assets. Use this work to stop unnecessary replacement of
+identically versioned package files described in
+[issue #613](https://github.com/archzfs/archzfs/issues/613). Define explicit
+criteria for rebuilding utilities and DKMS, and automate dependency-only
+`pkgrel` bumps and new-release resets tracked in
+[issue #623](https://github.com/archzfs/archzfs/issues/623).
+
+### OpenZFS Update Proposals
+
+**Status: Staging; dependent proposal in
+[PR #633](https://github.com/archzfs/archzfs/pull/633)**
+
+Use the watcher to open a reviewed `conf.sh` update pull request when OpenZFS
+publishes a release. Retain a human merge gate for source version and hash
+changes. This depends on PRs #627 and #632 and on explicitly configured GitHub
+permission for Actions to create pull requests.
+
+### Channel Implementation
+
+**Status: Design needed**
+
+Turn the release roles above into concrete names, URLs, package-selection rules,
+retention policies, and user migration instructions. Do not repurpose or rename
+the current public channel until users can transition without losing a working
+repository. Channel routing must preserve independently usable package sets and
+the create-then-promote publication invariant.
+
+## Test Infrastructure
+
+**Status: Priority; feasibility investigation needed**
+
+Build a modern GitHub-based suite around the available upstream OpenZFS test
+infrastructure, running against a current Arch Linux environment. Starting from
+the latest ArchISO is a candidate way to maximize compatibility with current
+installation media and packages, not yet a fixed implementation choice.
+
+The investigation should establish:
+
+- Which upstream OpenZFS tests can run reliably in an isolated ephemeral Arch
+  environment and what additional ArchZFS package, repository, boot, module,
+  and upgrade checks are needed.
+- Whether standard GitHub-hosted runners provide sufficient privilege, storage,
+  kernel features, KVM access, and execution time.
+- How to ensure failed package candidates remain ephemeral and never reach an
+  end-user release.
+- How to keep the suite reproducible and maintainable by multiple people.
+
+Prefer GitHub-hosted or otherwise shared reproducible infrastructure. Consider
+self-hosted runners only as a last resort and only with an explicit plan for
+redundancy and maintenance; testing must not recreate the former single-host,
+single-maintainer dependency.
+
+Passing this suite is a publication gate for every public channel. It does not
+promote packages from compatibility edge to stable or make unreleased upstream
+code satisfy stable policy.
+
+## Keyring and Trust
+
+**Status: Priority; packaging proposed in
+[archzfs-keyring PR #1](https://github.com/archzfs/archzfs-keyring/pull/1)**
+
+Complete the ArchZFS keyring package, its review and release procedure, and its
+integration into the production repository. The intended trust model should use
+maintainer keys to certify the release key rather than asking each user to make
+that release key locally trusted. Preserve the current release-key verification
+path until the package and migration instructions are deployed.
+
+## Distribution and Retention
+
+**Status: Design needed**
+
+Define authoritative sources, signature checks, and retention for official Arch
+kernel packages included in stable. Coordinate that policy with mirror archives
+and the separately maintained historical packages at `kernels.archzfs.com`, but
+do not make a self-contained stable repository depend on that external service.
+
+Resolve the remaining `archzfs.com` domain, redirect, user-migration, and archive
+questions tracked in [issue #599](https://github.com/archzfs/archzfs/issues/599).
+
+## Maintainability Investigation
+
+**Status: Design needed**
+
+The repository predates the current GitHub release architecture and contains
+substantial complexity from older operating models. Before proposing a broad
+refactor, inventory the requirements and exact call graph of the supported
+production path, identify complexity that no longer serves current needs, and
+evaluate smaller and more direct implementations, including closer use of Arch
+`devtools` where appropriate.
+
+Any redesign needs its own proposal, migration plan, and validation strategy.
+This roadmap does not assume that `clean-chroot-manager` should be removed, that
+a particular replacement is sufficient, or that old-looking code is unused.
+
+## Open Policy Questions
+
+- What final names best distinguish stable, compatibility-edge, feature-preview,
+  and CI-only artifacts?
+- Which official Arch kernel families does stable promise to carry?
+- From which authoritative archives are matching kernels and headers obtained,
+  and for how long are superseded compatible sets retained?
+- What user migration avoids disruption when the current `experimental` URL and
+  repository role change?
+- Is a separate feature-preview channel justified, or should such packages stay
+  unpublished outside targeted development tests?
+- What minimum hosted-runner test coverage is required before any public
+  package set is published?


### PR DESCRIPTION
## Dependency

PR #644 is merged. This PR now targets `master` and contains only the roadmap changes.

## Motivation

ArchZFS has several related priority efforts across release channels, kernel automation, mirrors, testing, key trust, and maintainability, but their intended roles and dependencies are spread across issues, pull requests, discussions, and repositories. Recording the current maintainer direction should make policy disagreements visible before implementation and prevent infrastructure staging, package validation, and end-user release maturity from being conflated.

## Proposed direction

- Define provisional roles for stable, compatibility-edge, optional feature-preview, and CI-only artifacts without prematurely fixing their final names.
- Require stable to combine proven infrastructure with released OpenZFS support and a self-contained set of matching, unmodified official Arch kernels and headers.
- Treat compatibility-edge packages as tested but higher-risk when they depend on unreleased upstream compatibility work; passing tests does not promote them to stable.
- Keep release-infrastructure validation in `archzfs-testing` separate from package testing and user-facing channels.
- Prioritize completing and deploying mirror automation, then review #627 as the foundation for selective builds and later OpenZFS update proposals.
- Attribute the public mirror to CART Lab at the University of Plovdiv while retaining the warning that automatic synchronization is not deployed.
- Describe a hosted-first feasibility investigation for a modern Arch/OpenZFS test suite, with self-hosted runners only as a last resort.
- Record keyring, retention, migration, and maintainability work while leaving broad refactoring choices to a dedicated investigation.

The document explicitly labels staging, priority, and design-needed work. It is not a release schedule and does not describe proposals as current production behavior.

## Operational impact

Documentation only. This changes no package inputs, workflows, signing, publication, mirror deployment, or release-channel behavior.

## Validation

- Ran `git diff --check` on the complete stacked diff.
- Verified local documentation links and reviewed the roadmap against current PRs #627, #632, and #633; issues #586, #599, #613, and #623; and the keyring and mirror PRs.
- Verified the University and CART Lab attribution links.
- Confirmed the branch contains three focused roadmap commits beyond the merged #644 foundation.

The privileged package build was not run because no executable or package input changed.

## Review focus

Because this is intentionally a policy draft, feedback is especially requested on release-role boundaries, priority ordering, stable kernel scope, artifact retention, and the minimum publication test gate.