### PR TITLE
docs: coordinate public documentation updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,17 @@
 - The Actions workflow named `Test` performs an unsigned package build and
   updates the shared mutable `testing` release. It does not run the legacy
   QEMU tests or an OpenZFS runtime/data-integrity suite.
+- Long package-build checks may run automatically for changes that cannot affect
+  their workflow, inputs, or outputs. After inspecting the changed paths and
+  relevant workflow dependencies, do not wait synchronously merely for such a
+  check to complete. Confirm that the run reached its expected long-running
+  step, report its pending status and URL, and do not claim that it passed or
+  cancel it.
+- Wait for or investigate a check when the change can affect it, when it fails
+  unexpectedly, or when its result is required for a requested merge, release,
+  or readiness decision. Documentation-only changes commonly qualify for
+  non-blocking treatment, but file type alone is not sufficient; verify the
+  dependency boundary first.
 - For shell-only changes, at minimum run `bash -n` on each changed Bash script
   and `git diff --check`. The initcpio hook declares ash/dash compatibility, so
   Bash syntax alone is insufficient for changes to that file.
@@ -117,7 +128,10 @@
   dependencies and merge order explicitly.
 - GitHub Wiki changes have no normal pull-request path. Prepare them in a local
   Wiki clone on a named branch, commit the proposed pages, and provide the diff
-  and summary for review. Push Wiki `master` only with explicit authorization.
+  and summary for review. Verify new or changed link targets before publication
+  and check rendered links afterward. If a target intentionally depends on
+  unmerged work, add an explicit dependency notice and tracked cleanup. Push
+  Wiki `master` only with explicit authorization.
 - PRs affecting public behavior should state which documentation surfaces were
   reviewed, which were updated, and any coordinated follow-up still required.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@
 ## Documentation Coordination
 
 - When package, release, signing, mirror, repository-role, or user-facing
-  behavior changes, review this repository's README and `docs/`, the public
-  [ArchZFS organization `.github` repository](https://github.com/archzfs/.github),
-  and the ArchZFS Wiki for affected claims.
+  behavior changes, review this repository's README, `docs/`, and applicable
+  `ci/releases/body-*.md` files, the public [ArchZFS organization `.github`
+  repository](https://github.com/archzfs/.github), and the ArchZFS Wiki for
+  affected claims.
 - The organization `.github` repository is a separate Git repository, not the
   `.github/` directory in this checkout. GitHub does not copy its profile or
   default community files into repository clones. Inspect it through GitHub or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,15 @@
 # ArchZFS Agent Instructions
 
-## Repository Role
+## Repository Identity
 
-- This is the production control repository for ArchZFS package generation,
-  builds, signing, and GitHub Releases publication.
+- These instructions are canonical in `archzfs/archzfs` and may be copied
+  unchanged into the disposable `archzfs-testing` fork. Identify the current
+  GitHub repository before release or synchronization work.
+- In `archzfs/archzfs`, this tree is the production control repository for
+  package generation, builds, signing, and GitHub Releases publication.
+- In `archzfs/archzfs-testing`, `master`, experiment branches, tags, and releases
+  are staging resources. They remain mutating shared infrastructure and still
+  require explicit authorization before reset, publication, or deletion.
 - Treat current workflows and scripts as authoritative over the old wiki,
   `TODO.rst`, and legacy deployment comments.
 - `archzfs-testing` is the staging fork for release-infrastructure changes.
@@ -68,6 +74,9 @@
 - Do not run `testing/test.sh` on an unreviewed environment. Its VM setup erases
   `/dev/vda`, depends on hard-coded NFS resources, and has unfinished acceptance
   checks.
+- Do not force-sync `archzfs-testing` until active work is preserved and
+  mutating workflows are disabled. `gh repo sync --force` hard-resets its target
+  branch; follow `docs/staging.md` and verify the destination repository.
 - Releases and tags named `testing`, `experimental`, and `failover` are mutable
   and may be force-moved. Do not use their tag commits as immutable provenance.
 - Preserve create-then-promote publication for fixed-name release channels. In
@@ -106,3 +115,5 @@
   referenced by `build-container/entrypoint.sh`.
 - Read `docs/architecture.md` before changing package ownership, release
   publication, signing, failover, or cross-repository behavior.
+- Read `docs/staging.md` before synchronizing `archzfs-testing` or using it to
+  validate release-infrastructure changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,27 @@
 - Call out generated files, release behavior, signing implications, destructive
   operations, and validation that could not be performed.
 
+## Documentation Coordination
+
+- When package, release, signing, mirror, repository-role, or user-facing
+  behavior changes, review this repository's README and `docs/`, the public
+  [ArchZFS organization `.github` repository](https://github.com/archzfs/.github),
+  and the ArchZFS Wiki for affected claims.
+- The organization `.github` repository is a separate Git repository, not the
+  `.github/` directory in this checkout. GitHub does not copy its profile or
+  default community files into repository clones. Inspect it through GitHub or
+  a separately cloned checkout, and verify that checkout's remote before use.
+- Do not place repository-critical operational instructions only in the
+  organization `.github` repository.
+- Update source-controlled documentation in the same change when practical.
+  Cross-repository documentation requires separate linked PRs; state
+  dependencies and merge order explicitly.
+- GitHub Wiki changes have no normal pull-request path. Prepare them in a local
+  Wiki clone on a named branch, commit the proposed pages, and provide the diff
+  and summary for review. Push Wiki `master` only with explicit authorization.
+- PRs affecting public behavior should state which documentation surfaces were
+  reviewed, which were updated, and any coordinated follow-up still required.
+
 ## Historical Boundaries
 
 - GitHub Actions and GitHub Releases are the supported production path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,9 @@
 - Do not run `repo.sh`, `push.sh`, `mirror.sh`, signing commands, remote rsync,
   or release workflows without explicit authorization and environment review.
   These paths can move, delete, sign, commit, push, or publish artifacts.
-- Do not run `testing/test.sh` on an unreviewed environment. Its VM setup erases
-  `/dev/vda`, depends on hard-coded NFS resources, and has unfinished acceptance
-  checks.
+- Do not run `testing/test.sh` on an unreviewed environment. Guest setup wipes
+  the test VM's `/dev/vda`, depends on hard-coded NFS resources, and has
+  unfinished acceptance checks.
 - Do not force-sync `archzfs-testing` until active work is preserved and
   mutating workflows are disabled. `gh repo sync --force` hard-resets its target
   branch; follow `docs/staging.md` and verify the destination repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,9 +110,12 @@ User documentation must not imply that keyring-package deployment is complete.
 
 `archzfs/archzfs-mirror` is intended to provide reusable tooling that
 synchronizes GitHub Releases to mirrors. Its implementation is not part of this
-repository's production publication path. The public
-[Plovdiv mirror](https://mirrors.uni-plovdiv.net/archzfs/) is operated
-separately; its availability does not make unfinished reusable mirror tooling
+repository's production publication path. The
+[Computer-Assisted Research and Teaching Laboratory](https://cart.uni-plovdiv.net/)
+at the [University of Plovdiv](https://uni-plovdiv.bg/) separately hosts a
+[public mirror](https://mirrors.uni-plovdiv.net/archzfs/). The replacement
+synchronization tooling is not deployed, so automatic freshness is not assured;
+the endpoint's availability does not make unfinished reusable mirror tooling
 production code.
 
 ### Generated package repositories

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,9 +88,16 @@ release tag's Git commit as permanent artifact identity.
 ### archzfs-testing
 
 `archzfs/archzfs-testing` is a staging fork for release-infrastructure changes.
-It can carry watcher, selective-build, or update-automation work that has not
-been merged into production. Its releases are staging artifacts and are not
-interchangeable with signed releases from this repository.
+Its `master` branch is intended to start unrelated experiments at the same
+source commit as production, then diverge only for the active test. Watcher,
+selective-build, or update-automation work may run there before being proposed
+for production.
+
+Source synchronization does not copy repository settings, credentials,
+environments, releases, tags, or workflow enabled state. Testing releases are
+staging artifacts and are not interchangeable with signed releases from this
+repository. The destructive synchronization and verification procedure is
+documented in [staging.md](staging.md).
 
 ### archzfs-keyring
 

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,221 @@
+# Release Infrastructure Staging
+
+This document defines how `archzfs-testing` is synchronized and used to validate
+release-infrastructure changes before they are proposed for production. It does
+not describe package maturity or an end-user testing repository.
+
+## Model
+
+`archzfs-testing/master` is a disposable, temporarily divergent copy of
+`archzfs/master`, not an independently maintained source tree. At the start of
+an unrelated experiment, its source should match production exactly. Divergence
+should consist only of the active experiment and any clearly separated
+testing-only adaptation needed to exercise it.
+
+Canonical instructions and documentation live in `archzfs/archzfs` and are
+copied into the fork. Do not add persistent testing-only `AGENTS.md`,
+`CLAUDE.md`, README, or workflow documentation to testing `master`; forced
+synchronization is intended to replace them.
+
+The testing repository's GitHub description and settings provide its persistent
+identity. Experiment branches preserve work that must survive a reset.
+
+## Why a Separate Repository Exists
+
+Pull-request workflows intentionally receive restricted credentials, especially
+for contributions from forks. They can build packages but cannot safely prove
+that code under review creates, replaces, renames, or deletes releases and tags
+correctly.
+
+Running the candidate workflow in `archzfs-testing` confines its
+repository-scoped write access to staging resources instead of production. The
+token may still mutate releases, tags, branches, and other testing-repository
+state allowed by the workflow permissions. A successful staging run supplements
+the production PR checks; it does not replace review or prove that every
+production setting is equivalent.
+
+## Safety Invariants
+
+- Treat every force-sync, workflow enablement, release mutation, tag update, and
+  branch deletion as an explicitly authorized operation.
+- Confirm the destination is `archzfs/archzfs-testing` immediately before every
+  destructive or publishing command. Never substitute `archzfs/archzfs` in a
+  staging command.
+- Preserve active experiment commits on a named remote branch before resetting
+  testing `master`.
+- Disable mutating and scheduled workflows before synchronization. Verify their
+  state again afterward; workflow files and enabled state are separate concerns.
+- Never copy the production private signing key into the staging repository.
+  Unsigned staging assets are expected unless a distinct non-production trust
+  design is introduced and documented.
+- Do not treat mutable staging tags or releases as immutable provenance. Record
+  the tested commit SHA and workflow-run URLs.
+
+## Synchronization Procedure
+
+### 1. Inventory and Preserve State
+
+Check the repository identity, active workflows, current runs, branches, and the
+commits that differ from production. Determine whether any open production PR
+or unresolved experiment still depends on testing `master`.
+
+Useful read-only commands include:
+
+```sh
+gh repo view archzfs/archzfs-testing --json nameWithOwner,parent,defaultBranchRef
+gh workflow list --all --repo archzfs/archzfs-testing
+gh run list --repo archzfs/archzfs-testing
+git remote -v
+git fetch --all --prune
+git log --oneline --left-right origin/master...archzfs/master
+```
+
+The final command assumes the production repository is configured locally as
+the `archzfs` remote. Inspect remote URLs rather than assuming remote names.
+
+Before a reset, preserve relevant testing `master` history on a descriptive
+branch such as `experiment/kernel-watcher` or
+`archive/kernel-watcher-2026-07-11`. Push and verify that branch before
+continuing. Keep it until the corresponding production work is merged or
+abandoned explicitly.
+
+### 2. Disable Mutating Workflows
+
+List workflows first because the available files depend on the current
+experiment. Disable release, watcher, update, or other workflows that publish,
+delete, dispatch privileged work, or run on a schedule. For example, when those
+files exist:
+
+```sh
+gh workflow disable release.yml --repo archzfs/archzfs-testing
+gh workflow disable watcher.yml --repo archzfs/archzfs-testing
+gh workflow disable update-zfs.yml --repo archzfs/archzfs-testing
+```
+
+Do not synchronize while a mutating run is active. Canceling a run is itself a
+state-changing operation and requires the same environment review.
+
+### 3. Force-Sync the Default Branch
+
+The normal fork-sync operation only fast-forwards when possible. Testing
+`master` normally has unique experiment commits, so exact parity requires the
+explicitly destructive form:
+
+```sh
+gh repo sync archzfs/archzfs-testing \
+  --source archzfs/archzfs \
+  --branch master \
+  --force
+```
+
+`--force` hard-resets the destination branch to the source branch. It does not
+synchronize or clean releases, tags, Actions variables, secrets, environments,
+permissions, workflow enabled state, caches, branch protection, or repository
+metadata.
+
+After synchronization, compare the remote commit SHAs rather than relying on a
+successful command alone:
+
+```sh
+gh api repos/archzfs/archzfs/commits/master --jq .sha
+gh api repos/archzfs/archzfs-testing/commits/master --jq .sha
+gh workflow list --all --repo archzfs/archzfs-testing
+```
+
+Prefer a fresh clone or worktree for the synchronized source. Do not hard-reset
+an existing local checkout until its uncommitted work and local-only commits
+have been reviewed and preserved.
+
+## Experiment Structure
+
+Create a named candidate branch from the synchronized production commit. Keep
+commits intended for production free of testing-only release names, credentials,
+or documentation.
+
+If repository settings cannot express a required staging difference, create a
+separate testing-only commit on top of the production candidate. Record that
+difference in the eventual PR and do not transfer the adaptation commit to
+production. A test with such an overlay is evidence for the shared code below
+it, not proof that the production workflow was tested byte-for-byte.
+
+Testing workflows currently depend on `master` push, schedule, or dispatch
+behavior. Advance testing `master` to the experiment only after the required
+workflow is enabled and the destination has been rechecked. Enabling a synced
+production workflow may also restore its schedule, so disable it again when the
+experiment is complete.
+
+Repository context should provide most isolation automatically: release actions
+using `github.repository` mutate the testing repository. Review hard-coded URLs
+separately. The builder currently reads signed failover assets from the
+production `archzfs/archzfs` release; that is a read-only dependency, not a
+license to mutate production releases.
+
+## Environment Parity
+
+Before interpreting a staging result, compare every setting used by the changed
+workflow. Source synchronization does not copy:
+
+- Actions variables, secrets, and environments.
+- Environment protection and branch policies.
+- Default workflow-token permissions and allowed Actions policy.
+- Workflow enabled state, schedules already queued, caches, or artifacts.
+- Releases, assets, tags, branch protection, or repository metadata.
+
+Record relevant non-secret values and the names, but never the values, of
+required secrets. The production `Release` environment supplies signing
+material; staging must not contain that production private key. An unsigned
+staging build therefore does not validate production private-key import or
+signing unless a separate safe mechanism is deliberately provided.
+
+## Verification
+
+A green workflow conclusion is only the start of release verification. Check
+the behavior relevant to the change, including:
+
+- The checked-out commit SHA and workflow inputs.
+- The package families built, skipped, or reused from failover.
+- Expected package and repository signature behavior.
+- Temporary release creation and cleanup.
+- Final release asset completeness and repository database contents.
+- Tag targets and release dates after create-then-promote publication.
+- Per-kernel failover behavior when only one build fails.
+- Preservation of the previous usable release when failure occurs before
+  promotion.
+- Safe repeated execution where idempotence is expected.
+- Absence of writes to production repositories, releases, tags, or branches.
+
+Keep links to the workflow runs and releases in the production PR description.
+If failure-path testing would require deliberately breaking or deleting shared
+staging resources, describe and authorize that test separately.
+
+## Production Pull Request
+
+Preserve the exact production-intended candidate commits after staging. Push
+those commits, without any testing-only overlay, to a named branch used for the
+PR against `archzfs/master`. Avoid manually recreating an already tested diff;
+retaining the commit object or applying the exact patch makes provenance easier
+to review.
+
+The production PR should state:
+
+- The production commit or patch tested and any staging-only differences.
+- Relevant testing workflow runs and release results.
+- Environment differences that staging did not cover, especially signing.
+- Failure paths, retries, or destructive cases that were not exercised.
+- Expected release, tag, failover, and generated-artifact impact.
+
+Normal production PR checks still apply. Their inability to mutate a shared
+release from fork-originated code is a known boundary, not a reason to grant
+untrusted code broader credentials.
+
+## Cleanup
+
+After verification, disable mutating staging workflows and ensure no unexpected
+scheduled run remains active. Retain the experiment branch and evidence until
+the production PR is resolved. Before unrelated work begins, repeat the
+inventory and force-sync procedure rather than accumulating experiments on
+testing `master`.
+
+Releases and tags may be cleaned when a test requires it, but they are shared
+staging state and need explicit authorization. Branch synchronization alone does
+not remove them.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -43,8 +43,10 @@ production setting is equivalent.
   staging command.
 - Preserve active experiment commits on a named remote branch before resetting
   testing `master`.
-- Disable mutating and scheduled workflows before synchronization. Verify their
-  state again afterward; workflow files and enabled state are separate concerns.
+- Disable mutating and scheduled workflows, then disable repository-level
+  Actions before synchronization. Keep Actions disabled until workflows
+  introduced by the synchronized tree have been inventoried and any mutating or
+  scheduled workflows have been disabled.
 - Never copy the production private signing key into the staging repository.
   Unsigned staging assets are expected unless a distinct non-production trust
   design is introduced and documented.
@@ -62,7 +64,9 @@ or unresolved experiment still depends on testing `master`.
 Useful read-only commands include:
 
 ```sh
-gh repo view archzfs/archzfs-testing --json nameWithOwner,parent,defaultBranchRef
+gh api repos/archzfs/archzfs-testing \
+  --jq '{full_name, fork, parent: .parent.full_name, default_branch, permissions}'
+gh auth status
 gh workflow list --all --repo archzfs/archzfs-testing
 gh run list --repo archzfs/archzfs-testing
 git remote -v
@@ -73,18 +77,45 @@ git log --oneline --left-right origin/master...archzfs/master
 The final command assumes the production repository is configured locally as
 the `archzfs` remote. Inspect remote URLs rather than assuming remote names.
 
+Abort unless the destination is exactly `archzfs/archzfs-testing`, reports
+`fork: true`, has `archzfs/archzfs` as its parent, and uses `master` as its
+default branch. The authenticated identity must have repository administration
+and contents-write access for the complete procedure.
+
+A GitHub CLI OAuth token or classic personal access token that adds or updates
+files under `.github/workflows/` requires the `workflow` scope in addition to
+repository write access. Repository administration does not substitute for that
+token scope. If `gh auth status` does not report it, stop and obtain explicit
+authorization before changing authentication.
+
 Before a reset, preserve relevant testing `master` history on a descriptive
 branch such as `experiment/kernel-watcher` or
 `archive/kernel-watcher-2026-07-11`. Push and verify that branch before
 continuing. Keep it until the corresponding production work is merged or
 abandoned explicitly.
 
-### 2. Disable Mutating Workflows
+### 2. Record Settings and Disable Actions
 
-List workflows first because the available files depend on the current
-experiment. Disable release, watcher, update, or other workflows that publish,
-delete, dispatch privileged work, or run on a schedule. For example, when those
-files exist:
+Record the current repository Actions policy, default workflow-token
+permissions, active runs, and per-workflow enabled states. Inspect `master`
+branch protection and repository rulesets; do not attempt the force-sync unless
+the reset is permitted or an explicitly authorized bypass is available.
+
+```sh
+gh api repos/archzfs/archzfs-testing/branches/master
+gh api repos/archzfs/archzfs-testing/rulesets
+gh api repos/archzfs/archzfs-testing/actions/permissions
+gh api repos/archzfs/archzfs-testing/actions/permissions/workflow
+gh workflow list --all --repo archzfs/archzfs-testing
+gh run list --repo archzfs/archzfs-testing
+```
+
+Let mutating runs finish before proceeding. Canceling a run is itself a
+state-changing operation and requires explicit authorization.
+
+Disable release, watcher, update, or other currently present workflows that
+publish, delete, dispatch privileged work, or run on a schedule. For example,
+when those files exist:
 
 ```sh
 gh workflow disable release.yml --repo archzfs/archzfs-testing
@@ -92,8 +123,17 @@ gh workflow disable watcher.yml --repo archzfs/archzfs-testing
 gh workflow disable update-zfs.yml --repo archzfs/archzfs-testing
 ```
 
-Do not synchronize while a mutating run is active. Canceling a run is itself a
-state-changing operation and requires the same environment review.
+Then disable Actions for the entire repository so workflows introduced by the
+synchronized production tree cannot start before they are reviewed:
+
+```sh
+gh api --method PUT \
+  repos/archzfs/archzfs-testing/actions/permissions \
+  -F enabled=false
+```
+
+Keep the recorded settings available for the restore step. Do not assume the
+current values or hard-code a permissive replacement policy.
 
 ### 3. Force-Sync the Default Branch
 
@@ -108,6 +148,13 @@ gh repo sync archzfs/archzfs-testing \
   --force
 ```
 
+The command first uses GitHub's fork-only upstream-merge operation and may fall
+back to moving the destination ref directly. That fallback cannot transfer
+missing Git objects; it can only reference commits already in the destination's
+object network. Continuous synchronization of new production commits therefore
+requires preserving `archzfs-testing` as a GitHub fork of `archzfs`. If the
+testing repository is recreated, recreate it as a fork.
+
 `--force` hard-resets the destination branch to the source branch. It does not
 synchronize or clean releases, tags, Actions variables, secrets, environments,
 permissions, workflow enabled state, caches, branch protection, or repository
@@ -121,6 +168,13 @@ gh api repos/archzfs/archzfs/commits/master --jq .sha
 gh api repos/archzfs/archzfs-testing/commits/master --jq .sha
 gh workflow list --all --repo archzfs/archzfs-testing
 ```
+
+While repository Actions remain disabled, inventory every workflow introduced
+by the synchronized tree and disable each mutating or scheduled workflow. After
+the commit SHAs and workflow states are verified, restore the exact recorded
+repository Actions policy and default workflow-token permissions. Explicitly
+enable only the workflow needed for the authorized experiment; do not broadly
+enable all synchronized workflows.
 
 Prefer a fresh clone or worktree for the synchronized source. Do not hard-reset
 an existing local checkout until its uncommitted work and local-only commits
@@ -139,8 +193,9 @@ production. A test with such an overlay is evidence for the shared code below
 it, not proof that the production workflow was tested byte-for-byte.
 
 Testing workflows currently depend on `master` push, schedule, or dispatch
-behavior. Advance testing `master` to the experiment only after the required
-workflow is enabled and the destination has been rechecked. Enabling a synced
+behavior. Advance testing `master` to the experiment only after the destination
+has been rechecked, the repository Actions policy has been restored, and the
+single required workflow has been explicitly enabled. Enabling a synced
 production workflow may also restore its schedule, so disable it again when the
 experiment is complete.
 


### PR DESCRIPTION
## Dependency

PR #646 is merged. This PR was retargeted to `master`, and its final review diff contained only the documentation-coordination changes.

The organization profile and inherited contribution guide have merged through [archzfs/.github#1](https://github.com/archzfs/.github/pull/1).

## Motivation

Release, signing, mirror, package, and repository-role changes can make several public documentation surfaces stale at once. GitHub organization defaults add another easy-to-miss boundary: they are displayed by GitHub but are not copied into ordinary repository clones, while Wiki changes have no normal pull-request review path.

Agents and contributors need an explicit coordination rule so repository-local docs, organization-level guidance, and the Wiki do not silently contradict deployed behavior.

## Changes

- Require relevant changes to review the central README and docs, the separate public ArchZFS organization `.github` repository, and the Wiki.
- Clarify that the organization repository is not the `.github/` directory in this checkout and may require a separately verified clone or GitHub access.
- Require linked PRs and explicit merge ordering for cross-repository documentation.
- Define a reviewable Wiki workflow: prepare and commit changes on a local branch, provide the diff and summary, and push Wiki `master` only with explicit authorization.
- Attribute the public mirror to CART Lab at the University of Plovdiv and retain the warning that replacement synchronization is not deployed.

## Operational impact

Documentation only. This changes no package inputs, workflows, releases, mirror deployment, signing, or generated repositories. It does establish expectations for future PR descriptions and coordinated documentation follow-up.

## Validation

- Ran `git diff --check` on the complete stacked diff.
- Verified that GitHub organization default community files are not copied into repository clones.
- Verified the organization repository URL and University/CART Lab attribution links.
- Confirmed this branch contains three focused coordination commits beyond #646.

No privileged build or publication operation was run because no executable input changed.

## Wiki coordination

Wiki refresh commits `46235a0` and `fd5baee` are published with current release, signing, package, mirror, build, testing, and issue-reporting guidance. Temporary dependency notices remain on the Wiki Home and Development pages until #644 and archzfs/.github#1 merge; their removal is tracked in those PR descriptions.

## Review follow-up

Commit `af18c38` requires pre-publication and rendered post-publication Wiki link verification, including notices and tracked cleanup for intentional pending dependencies. It also tells agents not to wait synchronously for unrelated long package builds after verifying the workflow dependency boundary, while preserving required investigation for affected, failed, merge-critical, or release-critical checks.