### PR TITLE
Update OpenZFS to 2.4.3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -317,7 +317,8 @@ for (( i = 0; i < ${#modes[@]}; i++ )); do
     for func in "${update_funcs[@]}"; do
         debug "Evaluating '${func}'"
 
-        # skip git packages if -s was used
+        # Production does not publish RC or Git packages. Review their
+        # generators and source-version assumptions before enabling them.
         if [[ ${only_stable} -eq 1 && ( ${func} =~ git_pkgbuilds$ || ${func} =~ rc_pkgbuilds$ ) ]]; then
             debug "Skipping '${func}' (non stable)"
             continue

--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,14 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.4.2"
+openzfs_version="2.4.3"
+
+# RC packages are currently disabled. These retained values are not production
+# release inputs; review the complete RC path before updating or re-enabling it.
 openzfs_rc_version="2.4.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f"
+zfs_src_hash="1f08f2d154f5189b5f1382848a32667b3d34066145b474c49cd3d41a5fba59a7"
 zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"

--- a/conf.sh
+++ b/conf.sh
@@ -1,6 +1,8 @@
 # OpenZFS stable version
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
+# FIXME: remove the Linux-Maximum workaround in src/zfs/PKGBUILD.sh and
+# src/zfs-dkms/PKGBUILD.sh once the selected release declares Linux 7.1 or later
 #
 openzfs_version="2.4.3"
 

--- a/src/kernels/_utils.sh
+++ b/src/kernels/_utils.sh
@@ -3,7 +3,7 @@ mode_name="utils"
 mode_desc="Select and use the utils packages"
 
 # version
-pkgrel="2"
+pkgrel="1"
 
 # Version for GIT packages
 pkgrel_git="1"

--- a/src/zfs-dkms/PKGBUILD.sh
+++ b/src/zfs-dkms/PKGBUILD.sh
@@ -19,6 +19,13 @@ groups=("${archzfs_package_group}")
 conflicts=("zfs" "zfs-headers" "spl" "spl-headers")
 ${zfs_replaces}
 
+prepare() {
+    cd "${zfs_workdir}"
+    # openzfs/zfs#18682 confirms Linux 7.1 support after the 2.4.3 release.
+    sed -i 's/^Linux-Maximum: 7.0$/Linux-Maximum: 7.1/' META
+    grep -qx 'Linux-Maximum: 7.1' META
+}
+
 build() {
     cd "${zfs_workdir}"
     ./autogen.sh

--- a/src/zfs-dkms/PKGBUILD.sh
+++ b/src/zfs-dkms/PKGBUILD.sh
@@ -21,9 +21,14 @@ ${zfs_replaces}
 
 prepare() {
     cd "${zfs_workdir}"
-    # openzfs/zfs#18682 confirms Linux 7.1 support after the 2.4.3 release.
-    sed -i 's/^Linux-Maximum: 7.0$/Linux-Maximum: 7.1/' META
-    grep -qx 'Linux-Maximum: 7.1' META
+    case "\${pkgver}" in
+        2.4.2|2.4.3)
+            # These releases contain Linux 7.1 compatibility, but their
+            # metadata predates the support marker.
+            sed -Ei 's/^Linux-Maximum: (7\.0|99\.99)$/Linux-Maximum: 7.1/' META
+            grep -qx 'Linux-Maximum: 7.1' META
+            ;;
+    esac
 }
 
 build() {

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -25,7 +25,7 @@ provides=("zfs-utils" "spl-utils")
 install=zfs-utils.install
 conflicts=("zfs-utils" "spl-utils")
 ${zfs_utils_replaces}
-backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf' 'etc/sudoers.d/zfs')
+backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
 
 build() {
     cd "${zfs_workdir}"
@@ -50,10 +50,6 @@ package() {
     # Autoload the zfs module at boot
     mkdir -p "\${pkgdir}/etc/modules-load.d"
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
-
-    # fix permissions
-    chmod 750 \${pkgdir}/etc/sudoers.d
-    chmod 440 \${pkgdir}/etc/sudoers.d/zfs
 
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -23,9 +23,14 @@ depends=("kmod" "${zfs_utils_pkgname}" ${linux_depends})
 
 prepare() {
     cd "${zfs_workdir}"
-    # openzfs/zfs#18682 confirms Linux 7.1 support after the 2.4.3 release.
-    sed -i 's/^Linux-Maximum: 7.0$/Linux-Maximum: 7.1/' META
-    grep -qx 'Linux-Maximum: 7.1' META
+    case "\${_zfsver}" in
+        2.4.2|2.4.3)
+            # These releases contain Linux 7.1 compatibility, but their
+            # metadata predates the support marker.
+            sed -Ei 's/^Linux-Maximum: (7\.0|99\.99)$/Linux-Maximum: 7.1/' META
+            grep -qx 'Linux-Maximum: 7.1' META
+            ;;
+    esac
 }
 
 build() {

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -21,6 +21,13 @@ sha256sums=("${zfs_src_hash}")
 license=("CDDL")
 depends=("kmod" "${zfs_utils_pkgname}" ${linux_depends})
 
+prepare() {
+    cd "${zfs_workdir}"
+    # openzfs/zfs#18682 confirms Linux 7.1 support after the 2.4.3 release.
+    sed -i 's/^Linux-Maximum: 7.0$/Linux-Maximum: 7.1/' META
+    grep -qx 'Linux-Maximum: 7.1' META
+}
+
 build() {
     cd "${zfs_workdir}"
     ./autogen.sh


### PR DESCRIPTION
## Summary

- update OpenZFS from 2.4.2 to 2.4.3 using the upstream release checksum
- remove `zfs-utils` handling for `/etc/sudoers.d/zfs`, which upstream removed
- enable the Linux 7.1 support already present in OpenZFS 2.4.2 and 2.4.3
- reset the stable utilities `pkgrel` for the new upstream version
- clarify that RC and Git package inputs are not part of the current production build

## Rationale

OpenZFS 2.4.3 removes `/etc/sudoers.d/zfs`. The existing `backup` entry would consequently refer to a file absent from the package, while the permission adjustments would target paths that are no longer installed. This packaging adjustment must accompany the version update because OpenZFS 2.4.2 still provides that file.

The stable `zfs-utils` `pkgrel` is reset from 2 to 1, as required for a new upstream version.

OpenZFS has confirmed that the necessary Linux 7.1 compatibility changes are present starting with 2.4.2. The 2.4.2 release archive accidentally carries a `Linux-Maximum` value of `99.99`, while 2.4.3 restores the pre-validation limit of 7.0. Upstream subsequently validated the final Linux 7.1 release with ZTS and merged a metadata-only support update.

The generated prebuilt and DKMS recipes therefore normalize `Linux-Maximum` to 7.1 only for OpenZFS 2.4.2 and 2.4.3. The expected source values are checked, and RC, Git, and future releases remain unaffected. A reminder beside the configured OpenZFS version calls for removing the workaround once the selected release carries the required support marker itself.

This supersedes #641 and #642. It combines their useful changes atomically, adds the missing `pkgrel` reset, and retains attribution to their authors.

## Upstream verification

- OpenZFS 2.4.3 release: https://github.com/openzfs/zfs/releases/tag/zfs-2.4.3
- Signed checksums: https://github.com/openzfs/zfs/releases/download/zfs-2.4.3/zfs-2.4.3.sha256.asc
- Removal of `/etc/sudoers.d/zfs`: https://github.com/openzfs/zfs/pull/18626
- Linux 7.1 compatibility confirmation: https://github.com/openzfs/zfs/issues/18760#issuecomment-4919127088
- Linux 7.1 metadata update and ZTS result: https://github.com/openzfs/zfs/pull/18682
- Fix for the accidental `99.99` release metadata: https://github.com/openzfs/zfs/pull/18531

The configured SHA-256 is:

`1f08f2d154f5189b5f1382848a32667b3d34066145b474c49cd3d41a5fba59a7`

## Validation

Local checks:

- `bash -n` on all changed shell templates
- generated prebuilt and DKMS PKGBUILDs pass `bash -n`
- the gated metadata normalization produces 7.1 from the official 2.4.2 and 2.4.3 release archives
- `git diff --check`

The same-repository [Test run](https://github.com/archzfs/archzfs/actions/runs/29250082786) completed successfully and published the mutable `testing` release. It built OpenZFS 2.4.3 packages for utilities, DKMS, Linux 6.18 LTS, and the current Linux 7.1 standard, hardened, and zen kernels without failover. The resulting kernel packages all require `zfs-utils=2.4.3`.

The published `zfs-dkms` package contains `Linux-Maximum: 7.1`. Its source was also extracted and successfully configured and compiled into `spl.ko` and `zfs.ko` against Linux 7.1.3 headers without an experimental-kernel flag.

ArchZFS validation here covers package generation and compilation; it does not load the modules or exercise filesystem operations. Runtime confidence for Linux 7.1 relies on the upstream ZTS result linked above.

No generated package submodules were modified. RC and Git packages remain unpublished and are not enabled by this change.