### PR TITLE
ci: prevent cancellation during release promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release
 
 concurrency:
   group: release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@
 - Preserve create-then-promote publication for fixed-name release channels. In
   addition to reducing exposure to incomplete uploads, creating a fresh release
   updates the date shown by GitHub; updating assets in place does not.
+- While fixed-name package publication uses delete-then-rename promotion, its
+  release-mutating critical section must not be canceled. The current workflow
+  protects the whole run as a containment measure; make build work cancellable
+  only after separating it from publication and pinning failover inputs to a
+  complete generation.
 - Preserve failover database/package signature verification when changing the
   builder. A downloaded package is not eligible for reuse merely because its
   filename matches.


### PR DESCRIPTION
## Motivation

While reviewing #648, I found that the package `Release` workflow can cancel an active run when a newer qualifying push or scheduled run arrives.

#611 introduced create-then-promote publication so an incomplete upload does not replace the working repository and each package generation receives a meaningful publication date. The resulting promotion sequence uploads `_experimental`, deletes the existing `experimental` release, and then renames the temporary release. If automatic cancellation occurs between deletion and rename, the public Pacman repository can remain unavailable until manual recovery or a later release run reaches promotion.

The same policy also protects the in-place `failover` replacement, where interruption during `removeArtifacts: true` can leave the fallback release empty or partial.

## Change

Set `cancel-in-progress: false` for the package `Release` workflow and document the corresponding operational invariant.

GitHub still permits only one running and one pending member of the concurrency group by default. A newer run replaces an older pending run, so this does not create an unbounded queue.

No package inputs, signing behavior, release names, assets, tags, triggers, promotion order, or failover behavior change.

## Trade-off and Follow-up

This is a containment measure rather than the intended final design. A superseded build may now continue for roughly 20-25 minutes instead of being canceled.

A future redesign should separate cancellable build work from a serialized, non-cancellable signing and publication stage. That split also needs to pin failover input to a complete generation: the builder currently reads the mutable failover database early and may download fallback packages much later, while publication replaces failover assets in place. The independently concurrent `Test` workflow has the same pre-existing mutable-failover race.

#653 tracks that broader redesign, including bounded build execution, safe promotion, and immutable failover input. Until those boundaries are separated safely, protecting the entire workflow is the smallest reliable fix while retaining the properties introduced by #611.

## Operational Impact

Merging this PR changes `release.yml`, so it will trigger one production package release. The merged workflow definition will prevent that run from automatically canceling an older member of the same concurrency group.

The delete-and-rename sequence still has a brief non-atomic interval. Manual cancellation, runner loss, API failures, and the existing six-hour job timeout remain outside the protection provided here.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`
- No privileged local package build, because package and builder inputs are unchanged
- No deliberate cancellation or overlap test against production

I also reviewed the README, architecture and roadmap documentation, release body, organization profile, and Wiki. They require no update for this narrowly scoped concurrency change.

## Review Focus

Please verify the concurrency behavior, the delete-to-rename failure window, and the decision to keep the broader cancellable-build redesign separate.