### PR TITLE
Update to zfs 2.4.4

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -4,14 +4,14 @@
 # FIXME: remove the Linux-Maximum workaround in src/zfs/PKGBUILD.sh and
 # src/zfs-dkms/PKGBUILD.sh once the selected release declares Linux 7.1 or later
 #
-openzfs_version="2.4.3"
+openzfs_version="2.4.4"
 
 # RC packages are currently disabled. These retained values are not production
 # release inputs; review the complete RC path before updating or re-enabling it.
 openzfs_rc_version="2.4.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="1f08f2d154f5189b5f1382848a32667b3d34066145b474c49cd3d41a5fba59a7"
+zfs_src_hash="2a3c70d55a37cc71618a95a60e81ad66530201eb118d37741dc92efcf848c8b1"
 zfs_rc_src_hash="0068102a4162d7445b80218b882ff54e1acf3cfbeef909d53bd984ddcd9339b1"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
update to zfs 2.4.4
ZTS finished successful without any non-expected skips/failures: https://github.com/n0xena/archzfs/pull/42#issuecomment-5382271397 on 7.1.8-3